### PR TITLE
fix: catch and raise unauth exceptions in all paths to trigger refresh.

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -434,6 +434,16 @@ async def action_pull_observations(integration: Integration, action_config: Pull
     except ctrackcrystal.TooManyRequestsException:
         logger.warning("Rate limit (429) from Ctrack Crystal API")
         raise
+    except (ctrackcrystal.UnauthorizedException, ctrackcrystal.ForbiddenException) as e:
+        logger.error(f"Authentication failed for integration ID {integration.id}, username: {auth_config.username}: {e}")
+        await log_action_activity(
+            integration_id=str(integration.id),
+            action_id="pull_observations",
+            title="Authentication failed: check credentials in the portal",
+            level=LogLevel.ERROR,
+            data={"error": str(e), "username": auth_config.username},
+        )
+        raise
     except Exception as e:
         logger.error(f"Failed to process vehicles from integration ID {integration.id}, username: {auth_config.username}")
         raise e
@@ -507,6 +517,16 @@ async def action_fetch_vehicle_trips(integration, action_config: PullVehicleTrip
             level=LogLevel.ERROR,
             title=f"Rate limit exceeded fetching trips for vehicle {action_config.vehicle_id}.",
             data={"message": message, "data": action_config}
+        )
+        return {"observations_extracted": 0}
+    except (ctrackcrystal.UnauthorizedException, ctrackcrystal.ForbiddenException) as e:
+        logger.error(f"Authentication failed for integration ID {integration.id}: {e}")
+        await log_action_activity(
+            integration_id=integration.id,
+            action_id="pull_observations",
+            level=LogLevel.ERROR,
+            title="Authentication failed: check credentials in the portal",
+            data={"error": str(e)},
         )
         return {"observations_extracted": 0}
     except Exception as e:


### PR DESCRIPTION
This pull request improves error handling for authentication failures when interacting with the Ctrack Crystal API. Specifically, it adds explicit handling for unauthorized and forbidden exceptions, ensuring that authentication errors are logged with clear messages and that action activity is recorded appropriately.

**Authentication error handling improvements:**

* Added specific exception handling for `UnauthorizedException` and `ForbiddenException` in `_fetch_this_vehicle`, logging the error, recording an action activity with error details, and re-raising the exception.
* Added similar exception handling in `_do_fetch`, logging authentication failures, recording an action activity, and returning a result indicating no observations were extracted.